### PR TITLE
fixed test_start_pattern

### DIFF
--- a/handler/exercism.lua
+++ b/handler/exercism.lua
@@ -6,7 +6,7 @@ local function exists(path)
 end
 
 local test_file_format = './%s_spec.lua'
-local test_start_patt = '^(%s*)it%(\'(.+)\',%s*function%(%)$'
+local test_start_patt = '^(%s*)it%(\'(.+)\',%s*function.*$'
 local test_end_patt = '^(%s*)end%)$'
 
 local function parse_test_file(slug)


### PR DESCRIPTION
Fixed the `test_start_pattern` that caused the hamming tests to fail, because the spec file could not be parsed.

Closes #44