### PR TITLE
recognise test names using double quotes

### DIFF
--- a/handler/exercism.lua
+++ b/handler/exercism.lua
@@ -6,7 +6,7 @@ local function exists(path)
 end
 
 local test_file_format = './%s_spec.lua'
-local test_start_patt = '^(%s*)it%(\'(.+)\',%s*function.*$'
+local test_start_patt = '^(%s*)it%([\'"](.+)[\'"],%s*function.*$'
 local test_end_patt = '^(%s*)end%)$'
 
 local function parse_test_file(slug)

--- a/tests/example-success/example_success_spec.lua
+++ b/tests/example-success/example_success_spec.lua
@@ -16,4 +16,8 @@ describe('leap', function()
   it('turn of the 21st century', function()
     assert.is_true(is_leap_year(2400))
   end)
+
+  it("handles test names with 'apostrophes'", function()
+    assert.is_true(true)
+  end)
 end)

--- a/tests/example-success/expected_results.json
+++ b/tests/example-success/expected_results.json
@@ -21,6 +21,11 @@
       "name": "turn of the 21st century",
       "status": "pass",
       "test_code": "assert.is_true(is_leap_year(2400))"
+    },
+    {
+      "name": "handles test names with 'apostrophes'",
+      "status": "pass",
+      "test_code": "assert.is_true(true)"
     }
   ]
 }


### PR DESCRIPTION
The "react" exercise has a test name with an apostrophe, and therefore the name string uses double quotes, which wasn't being recognised.

This seems to fix the immediate issue, but I tried (and failed) to add an assertion to catch any future parsing issues.

Roughly what happens when `test_start_patt` doesn't match:
- the test code is completely skipped by `parse_test_file`
- busted still runs the test and stores the name in the handler
- `add_to_tests` raises an error when it can't find the test details
- busted seems to swallow the error
- everything silently fails

I added an assertion that the test is known, but of course this is silently swallowed too.

Any suggestions on how to make this easier to debug in the future?  I am completely new to lua and not familiar with busted's handler mechanism, but I see this is not the first similar issue (#45), and I could have save a lot of time tracking this down 😅 