### PR TITLE
Dockerfile: Fixed lua download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
     apt-get purge --auto-remove && \
     apt-get clean
 
-RUN curl -R -O http://www.lua.org/ftp/lua-${LUA_VER}.tar.gz && \
+RUN curl -R -O -L http://www.lua.org/ftp/lua-${LUA_VER}.tar.gz && \
     [ "$(sha256sum lua-${LUA_VER}.tar.gz | cut -d' ' -f1)" = "${LUA_CHECKSUM}" ] && \
     tar -zxf lua-${LUA_VER}.tar.gz && \
     cd lua-${LUA_VER} && \


### PR DESCRIPTION
now the hosting provider of lua.org changed end last year and the new one returns a 301