### PR TITLE
Fix executing Bob tests

### DIFF
--- a/handler/exercism.lua
+++ b/handler/exercism.lua
@@ -29,9 +29,9 @@ local function parse_test_file(slug)
     for test in test_file_contents:gmatch('%sit(%b())') do
         local name = test:match("^%(%s*(%b'')") or test:match('^%(%s*(%b"")')
         name = name:sub(2, -2)
-    
-        local code = test:match(',%s*function%(%)(.+)end%)$')
-        code = code:gsub('^%s*\n', '')        
+
+        local code = test:match(',%s*function%s*%(%)(.+)end%)$')
+        code = code:gsub('^%s*\n', '')
         local indent = code:match('^%s+')
         code = code:gsub('^' .. indent, ''):gsub('\n' .. indent, '\n'):gsub('%s+$', '')
 

--- a/tests/example-success/example_success_spec.lua
+++ b/tests/example-success/example_success_spec.lua
@@ -32,4 +32,8 @@ describe('leap', function()
     function()
       assert.is_true(true)
     end)
+
+  it('handles tests with a space after function and before () in the function definition', function ()
+    assert.is_true(true)
+  end)
 end)

--- a/tests/example-success/expected_results.json
+++ b/tests/example-success/expected_results.json
@@ -36,6 +36,11 @@
       "name": "handles really long test names that get wrapped by the lua formatter",
       "status": "pass",
       "test_code": "assert.is_true(true)"
+    },
+    {
+      "name": "handles tests with a space after function and before () in the function definition",
+      "status": "pass",
+      "test_code": "assert.is_true(true)"
     }
   ]
 }


### PR DESCRIPTION
See https://forum.exercism.org/t/an-error-occurred-when-testing-bob-in-lua/13083

This fixes an issue with tests that use `function ()` instead of `function()`. The latest version of all tests shouldn't have this because the formatter makes sure that it is written `function()`, but we didn't always have this. In particular, I see this in an old version of the Bob tests:

```lua
local bob = require('bob')

describe('Bob', function()

    it('stating something', function()
      local result = bob.hey('Tom-ay-to, tom-aaaah-to.')
      assert.are.equals('Whatever', result)
    end)

    it('shouting', function ()
      local result = bob.hey('WATCH OUT!')
      assert.are.equals('Whoa, chill out!', result)
    end)

    it('asking a question', function ()
      local result = bob.hey('Does this cryogenic chamber make me look fat?')
      assert.are.equals('Sure', result)
    end)

    it('talking forcefully', function ()
      local result = bob.hey("Let's go make out behind the gym!")
      assert.are.equals('Whatever', result)
    end)

    it('shouting numbers', function ()
      local result = bob.hey('1, 2, 3 GO!')
      assert.are.equals('Whoa, chill out!', result)
    end)

    it('shouting with special characters', function ()
      local result = bob.hey('ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!')
      assert.are.equals('Whoa, chill out!', result)
    end)

    it('silence', function ()
      local result = bob.hey('')
      assert.are.equals('Fine, be that way.', result)
    end)

end)
```
