### PR TITLE
Improve test parsing robustness

### DIFF
--- a/handler/exercism.lua
+++ b/handler/exercism.lua
@@ -29,7 +29,7 @@ local function parse_test_file(slug)
     pcall(function()
         load(test_file_contents, nil, 't', setmetatable({
             describe = function(_, fn)
-                pcall(fn)
+                fn()
             end,
 
             it = function(name, fn)

--- a/tests/example-success/example_success_spec.lua
+++ b/tests/example-success/example_success_spec.lua
@@ -17,6 +17,11 @@ describe('leap', function()
     assert.is_true(is_leap_year(2400))
   end)
 
+  it('handles tests with parens in strings', function()
+    local s = ')'
+    assert.is_true(true)
+  end)
+
   it("handles test names with 'apostrophes'", function()
     assert.is_true(true)
   end)

--- a/tests/example-success/expected_results.json
+++ b/tests/example-success/expected_results.json
@@ -23,6 +23,11 @@
       "test_code": "assert.is_true(is_leap_year(2400))"
     },
     {
+      "name": "handles tests with parens in strings",
+      "status": "pass",
+      "test_code": "local s = ')'\nassert.is_true(true)"
+    },
+    {
       "name": "handles test names with 'apostrophes'",
       "status": "pass",
       "test_code": "assert.is_true(true)"


### PR DESCRIPTION
This fixes the issue raised in https://forum.exercism.org/t/an-error-occurred-when-testing-bob-in-lua/13083. The root cause of the issue was a closing paren inside of a string that caused the `%b()` to find the end of the test too early.

My new approach takes advantage of the Lua parser to correctly find the test info by executing the test file and capturing the inputs to the `it` function. The `name` parameter is passed directly and the body is found using the `debug` library.