### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,11 @@ on:
   push:
     branches:
       - main
+  schedule:
+      - cron: "0 0 * * *"
 
 jobs:
-  build:
+  tests:
     name: Tests
     runs-on: ubuntu-22.04
     steps:
@@ -18,3 +20,13 @@ jobs:
 
       - name: Run Tests in Docker
         run: bin/run-tests-in-docker.sh
+
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+
+      - name: Run Integration Tests
+        run: bin/run-integration-tests-in-docker.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tests/**/results.json
+track

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV LUAROCKS_VER="3.9.2"
 ENV LUAROCKS_GPG_KEY="3FD8F43C2BB3C478"
 
 RUN apt-get update && \
-    apt-get install -y curl gcc jq make unzip gnupg && \
+    apt-get install -y curl gcc jq make unzip gnupg git && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get purge --auto-remove && \
     apt-get clean

--- a/bin/run-integration-tests-in-docker.sh
+++ b/bin/run-integration-tests-in-docker.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+
+# Synopsis:
+# Test the test runner by running it against all practice and concept exercises
+# in the track in the test runner Docker image.
+
+# Output:
+# Outputs errors for failed runs.
+
+# Example:
+# ./bin/run-integration-tests-in-docker.sh
+
+# Build the Docker image
+docker build --rm -t exercism/lua-test-runner .
+
+# Run the Docker image using the settings mimicking the production environment
+docker run \
+    --rm \
+    --mount type=bind,src="${PWD}/tests",dst=/opt/test-runner/tests \
+    --mount type=tmpfs,dst=/tmp \
+    --workdir /opt/test-runner \
+    --entrypoint /opt/test-runner/bin/run-integration-tests.sh \
+    exercism/lua-test-runner

--- a/bin/run-integration-tests.sh
+++ b/bin/run-integration-tests.sh
@@ -1,0 +1,38 @@
+#! /bin/sh
+
+# Synopsis:
+# Test the test runner by running it against all practice and concept exercises
+# in the track.
+
+# Output:
+# Outputs errors for failed runs.
+
+# Example:
+# ./bin/run-integration-tests.sh
+
+exit_code=0
+
+rm -rf track
+git clone https://github.com/exercism/lua track
+
+# Iterate over all exercise directories
+for exercise_dir in track/exercises/practice/* track/exercises/concept/*; do
+    exercise_slug=$(basename "${exercise_dir}")
+    exercise_dir_path=$(realpath "${exercise_dir}")
+    results_file="results.json"
+    results_file_path="${exercise_dir}/${results_file}"
+
+    bin/run.sh "${exercise_slug}" "${exercise_dir_path}" "${exercise_dir_path}" > /dev/null
+
+    if [ $? -ne 0 ]; then
+        echo "error: failed to run tests for $exercise_slug"
+        exit_code=1
+    fi
+
+    if ! grep -q '[^[:space:]]' "$results_file_path"; then
+        echo "error: generated empty result for $exercise_slug"
+        exit_code=1
+    fi
+done
+
+exit ${exit_code}

--- a/handler/exercism.lua
+++ b/handler/exercism.lua
@@ -32,6 +32,12 @@ local function parse_test_file(slug)
                 fn()
             end,
 
+            before_each = function()
+            end,
+
+            after_each = function()
+            end,
+
             it = function(name, fn)
                 local debug_info = debug.getinfo(fn, 'S')
 


### PR DESCRIPTION
This adds integration tests that make sure that the test runner can test all exercises defined in the track. This help to us to find out that the test runner is broken before our users do.

When running this I found that the `bowling` exercise failed because it uses `before_each`. I resolved this by adding stubs for `before_each` and `after_each` in the environment used to identify all tests.