### PR TITLE
use cgr.dev/chainguard/wolfi-base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,24 @@
-FROM ubuntu:24.04 AS builder
+# To refresh, copy the Digest from
+# `docker buildx imagetools inspect cgr.dev/chainguard/wolfi-base:latest`
+ARG WOLFI_BASE=cgr.dev/chainguard/wolfi-base@sha256:3258be472764337fd13095bcbb3182da170243b5819fd67ad4c0754590588b31
+
+FROM ${WOLFI_BASE} AS builder
 
 ENV LUA_VER="5.5.0"
 ENV LUA_CHECKSUM="57ccc32bbbd005cab75bcc52444052535af691789dba2b9016d5c50640d68b3d"
 ENV LUAROCKS_VER="3.13.0"
 ENV LUAROCKS_GPG_KEY="3FD8F43C2BB3C478"
 
-RUN apt-get update && \
-    apt-get install -y curl gcc make unzip gnupg && \
-    rm -rf /var/lib/apt/lists/*
+# build-base bundles gcc, make, glibc-dev and the standard linker.
+# gnupg is the umbrella, gpg supplies the cli binary, gnupg-dirmngr
+# the network agent for keyserver lookups.
+RUN apk add --no-cache build-base curl gnupg gnupg-dirmngr gpg gpg-agent
 
 RUN curl -R -O -L http://www.lua.org/ftp/lua-${LUA_VER}.tar.gz && \
     [ "$(sha256sum lua-${LUA_VER}.tar.gz | cut -d' ' -f1)" = "${LUA_CHECKSUM}" ] && \
     tar -zxf lua-${LUA_VER}.tar.gz && \
     cd lua-${LUA_VER} && \
-    make all install && \
-    cd .. && \
-    rm lua-${LUA_VER}.tar.gz && \
-    rm -rf lua-${LUA_VER}
+    make all install
 
 RUN curl -R -O -L https://luarocks.org/releases/luarocks-${LUAROCKS_VER}.tar.gz && \
     curl -R -O -L https://luarocks.org/releases/luarocks-${LUAROCKS_VER}.tar.gz.asc && \
@@ -24,16 +26,12 @@ RUN curl -R -O -L https://luarocks.org/releases/luarocks-${LUAROCKS_VER}.tar.gz 
     gpg --verify luarocks-${LUAROCKS_VER}.tar.gz.asc luarocks-${LUAROCKS_VER}.tar.gz && \
     tar -zxpf luarocks-${LUAROCKS_VER}.tar.gz && \
     cd luarocks-${LUAROCKS_VER} && \
-    ./configure && make && make install && \
-    cd .. && \
-    rm luarocks-${LUAROCKS_VER}.tar.gz.asc && \
-    rm luarocks-${LUAROCKS_VER}.tar.gz && \
-    rm -rf luarocks-${LUAROCKS_VER}
+    ./configure && make && make install
 
 RUN luarocks install busted
 
 
-FROM cgr.dev/chainguard/wolfi-base
+FROM ${WOLFI_BASE}
 
 # Wolfi is glibc-based, so the Lua interpreter and busted's compiled
 # C extensions built above run against Wolfi's glibc unmodified.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:24.04 AS builder
 
 ENV LUA_VER="5.5.0"
 ENV LUA_CHECKSUM="57ccc32bbbd005cab75bcc52444052535af691789dba2b9016d5c50640d68b3d"
@@ -6,10 +6,8 @@ ENV LUAROCKS_VER="3.13.0"
 ENV LUAROCKS_GPG_KEY="3FD8F43C2BB3C478"
 
 RUN apt-get update && \
-    apt-get install -y curl gcc jq make unzip gnupg git && \
-    rm -rf /var/lib/apt/lists/* && \
-    apt-get purge --auto-remove && \
-    apt-get clean
+    apt-get install -y curl gcc make unzip gnupg && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN curl -R -O -L http://www.lua.org/ftp/lua-${LUA_VER}.tar.gz && \
     [ "$(sha256sum lua-${LUA_VER}.tar.gz | cut -d' ' -f1)" = "${LUA_CHECKSUM}" ] && \
@@ -33,6 +31,17 @@ RUN curl -R -O -L https://luarocks.org/releases/luarocks-${LUAROCKS_VER}.tar.gz 
     rm -rf luarocks-${LUAROCKS_VER}
 
 RUN luarocks install busted
+
+
+FROM cgr.dev/chainguard/wolfi-base
+
+# Wolfi is glibc-based, so the Lua interpreter and busted's compiled
+# C extensions built above run against Wolfi's glibc unmodified.
+# bash + coreutils for the run scripts; lua/busted are otherwise
+# pure-Lua and don't pull additional shared libraries.
+RUN apk add --no-cache bash coreutils
+
+COPY --from=builder /usr/local /usr/local
 
 COPY . /opt/test-runner
 WORKDIR /opt/test-runner

--- a/bin/run-integration-tests-in-docker.sh
+++ b/bin/run-integration-tests-in-docker.sh
@@ -14,11 +14,17 @@ set -e
 # Build the Docker image
 docker build --rm -t exercism/lua-test-runner .
 
+# Clone the track on the host. Doing this here (not inside the
+# container) keeps git out of the production image.
+rm -rf track
+git clone https://github.com/exercism/lua track
+
 # Run the Docker image using the settings mimicking the production environment
 docker run \
     --rm \
     --mount type=bind,src="${PWD}/tests",dst=/opt/test-runner/tests \
+    --mount type=bind,src="${PWD}/track",dst=/opt/test-runner/track \
     --mount type=tmpfs,dst=/tmp \
     --workdir /opt/test-runner \
     --entrypoint /opt/test-runner/bin/run-integration-tests.sh \
-    exercism/lua-test-runner
+    exercism/lua-test-runner --skip-clone

--- a/bin/run-integration-tests-in-docker.sh
+++ b/bin/run-integration-tests-in-docker.sh
@@ -17,7 +17,7 @@ docker build --rm -t exercism/lua-test-runner .
 # Clone the track on the host. Doing this here (not inside the
 # container) keeps git out of the production image.
 rm -rf track
-git clone https://github.com/exercism/lua track
+git clone --depth 1 https://github.com/exercism/lua track
 
 # Run the Docker image using the settings mimicking the production environment
 docker run \

--- a/bin/run-integration-tests.sh
+++ b/bin/run-integration-tests.sh
@@ -4,6 +4,12 @@
 # Test the test runner by running it against all practice and concept exercises
 # in the track.
 
+# Arguments:
+# --skip-clone: do not (re)clone the track; assume `./track` is already
+#               populated. Used by run-integration-tests-in-docker.sh,
+#               which clones on the host so the container image does
+#               not need git.
+
 # Output:
 # Outputs errors for failed runs.
 
@@ -12,8 +18,10 @@
 
 exit_code=0
 
-rm -rf track
-git clone https://github.com/exercism/lua track
+if [ "$1" != "--skip-clone" ]; then
+    rm -rf track
+    git clone https://github.com/exercism/lua track
+fi
 
 # Iterate over all exercise directories
 for exercise_dir in track/exercises/practice/* track/exercises/concept/*; do

--- a/bin/run-integration-tests.sh
+++ b/bin/run-integration-tests.sh
@@ -20,7 +20,7 @@ exit_code=0
 
 if [ "$1" != "--skip-clone" ]; then
     rm -rf track
-    git clone https://github.com/exercism/lua track
+    git clone --depth 1 https://github.com/exercism/lua track
 fi
 
 # Iterate over all exercise directories


### PR DESCRIPTION
We compile Lua with ubuntu, then copy it
across to a much smaller image based on
cgr.dev/chainguard/wolfi-base

552MB becomes 54.7MB

(95 MB with git - was needed by run-integration-tests)
